### PR TITLE
Basic support for big-endian MIPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ endif
 
 # Architectures and modes to be compiled. Consider these to be internal
 # variables, don't override them (use the targets instead).
-ARCHES = ia32 x64 arm mipsel
+ARCHES = ia32 x64 arm mipsel mips
 DEFAULT_ARCHES = ia32 x64 arm
 MODES = release debug
 ANDROID_ARCHES = android_ia32 android_arm
@@ -151,10 +151,6 @@ all: $(MODES)
 buildbot:
 	$(MAKE) -C "$(OUTDIR)" BUILDTYPE=$(BUILDTYPE) \
 	        builddir="$(abspath $(OUTDIR))/$(BUILDTYPE)"
-
-mips mips.release mips.debug:
-	@echo "V8 does not support big-endian MIPS builds at the moment," \
-	      "please use little-endian builds (mipsel)."
 
 # Compile targets. MODES and ARCHES are convenience targets.
 .SECONDEXPANSION:

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -159,7 +159,7 @@
           'V8_TARGET_ARCH_IA32',
         ],
       }],  # v8_target_arch=="ia32"
-      ['v8_target_arch=="mipsel"', {
+      ['v8_target_arch=="mipsel" or v8_target_arch=="mips"', {
         'defines': [
           'V8_TARGET_ARCH_MIPS',
         ],
@@ -170,9 +170,11 @@
           ['mipscompiler=="yes"', {
             'target_conditions': [
               ['_toolset=="target"', {
-                'cflags': ['-EL'],
-                'ldflags': ['-EL'],
                 'conditions': [
+                  ['v8_target_arch=="mipsel"', {
+                    'cflags': ['-EL'],
+                    'ldflags': ['-EL'],
+                  }],
                   [ 'v8_use_mips_abi_hardfloat=="true"', {
                     'cflags': ['-mhard-float'],
                     'ldflags': ['-mhard-float'],
@@ -273,7 +275,7 @@
       ['(OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris" \
          or OS=="netbsd" or OS=="mac" or OS=="android") and \
         (v8_target_arch=="arm" or v8_target_arch=="ia32" or \
-         v8_target_arch=="mipsel")', {
+         v8_target_arch=="mipsel" or v8_target_arch=="mips")', {
         # Check whether the host compiler and target compiler support the
         # '-m32' option and set it if so.
         'target_conditions': [

--- a/build/standalone.gypi
+++ b/build/standalone.gypi
@@ -68,6 +68,7 @@
     'conditions': [
       ['(v8_target_arch=="arm" and host_arch!="arm") or \
         (v8_target_arch=="mipsel" and host_arch!="mipsel") or \
+        (v8_target_arch=="mips" and host_arch!="mips") or \
         (v8_target_arch=="x64" and host_arch!="x64") or \
         (OS=="android")', {
         'want_separate_host_toolset': 1,

--- a/src/atomicops_internals_mips_gcc.h
+++ b/src/atomicops_internals_mips_gcc.h
@@ -49,7 +49,6 @@ inline Atomic32 NoBarrier_CompareAndSwap(volatile Atomic32* ptr,
                                          Atomic32 old_value,
                                          Atomic32 new_value) {
   Atomic32 prev, tmp;
-#if defined(__MIPSEL__)
   __asm__ __volatile__(".set push\n"
                        ".set noreorder\n"
                        "1:\n"
@@ -64,22 +63,6 @@ inline Atomic32 NoBarrier_CompareAndSwap(volatile Atomic32* ptr,
                        : "=&r" (prev), "=m" (*ptr), "=&r" (tmp)
                        : "Ir" (old_value), "r" (new_value), "m" (*ptr)
                        : "memory");
-#else
-  __asm__ __volatile__(".set push\n"
-                       ".set noreorder\n"
-                       "1:\n"
-                       "lwc0 %0, %5\n"  // prev = *ptr
-                       "bne %0, %3, 2f\n"  // if (prev != old_value) goto 2
-                       "move %2, %4\n"  // tmp = new_value
-                       "swc0 %2, %1\n"  // *ptr = tmp (with atomic check)
-                       "beqz %2, 1b\n"  // start again on atomic error
-                       "nop\n"  // delay slot nop
-                       "2:\n"
-                       ".set pop\n"
-                       : "=&r" (prev), "=m" (*ptr), "=&r" (tmp)
-                       : "Ir" (old_value), "r" (new_value), "m" (*ptr)
-                       : "memory");
-#endif
   return prev;
 }
 
@@ -88,7 +71,6 @@ inline Atomic32 NoBarrier_CompareAndSwap(volatile Atomic32* ptr,
 inline Atomic32 NoBarrier_AtomicExchange(volatile Atomic32* ptr,
                                          Atomic32 new_value) {
   Atomic32 temp, old;
-#if defined(__MIPSEL__)
   __asm__ __volatile__(".set push\n"
                        ".set noreorder\n"
                        "1:\n"
@@ -101,20 +83,7 @@ inline Atomic32 NoBarrier_AtomicExchange(volatile Atomic32* ptr,
                        : "=&r" (temp), "=&r" (old), "=m" (*ptr)
                        : "r" (new_value), "m" (*ptr)
                        : "memory");
-#else
-  __asm__ __volatile__(".set push\n"
-                       ".set noreorder\n"
-                       "1:\n"
-                       "lwc0 %1, %2\n"  // old = *ptr
-                       "move %0, %3\n"  // temp = new_value
-                       "swc0 %0, %2\n"  // *ptr = temp (with atomic check)
-                       "beqz %0, 1b\n"  // start again on atomic error
-                       "nop\n"  // delay slot nop
-                       ".set pop\n"
-                       : "=&r" (temp), "=&r" (old), "=m" (*ptr)
-                       : "r" (new_value), "m" (*ptr)
-                       : "memory");
-#endif
+
   return old;
 }
 
@@ -123,7 +92,7 @@ inline Atomic32 NoBarrier_AtomicExchange(volatile Atomic32* ptr,
 inline Atomic32 NoBarrier_AtomicIncrement(volatile Atomic32* ptr,
                                           Atomic32 increment) {
   Atomic32 temp, temp2;
-#if defined(__MIPSEL__)
+
   __asm__ __volatile__(".set push\n"
                        ".set noreorder\n"
                        "1:\n"
@@ -136,20 +105,6 @@ inline Atomic32 NoBarrier_AtomicIncrement(volatile Atomic32* ptr,
                        : "=&r" (temp), "=&r" (temp2), "=m" (*ptr)
                        : "Ir" (increment), "m" (*ptr)
                        : "memory");
-#else
-  __asm__ __volatile__(".set push\n"
-                       ".set noreorder\n"
-                       "1:\n"
-                       "lwc0 %0, %2\n"  // temp = *ptr
-                       "addu %1, %0, %3\n"  // temp2 = temp + increment
-                       "swc0 %1, %2\n"  // *ptr = temp2 (with atomic check)
-                       "beqz %1, 1b\n"  // start again on atomic error
-                       "addu %1, %0, %3\n"  // temp2 = temp + increment
-                       ".set pop\n"
-                       : "=&r" (temp), "=&r" (temp2), "=m" (*ptr)
-                       : "Ir" (increment), "m" (*ptr)
-                       : "memory");
-#endif
   // temp2 now holds the final value.
   return temp2;
 }
@@ -191,11 +146,7 @@ inline void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value) {
 }
 
 inline void MemoryBarrier() {
-#if defined(__MIPSEL__)
   __asm__ __volatile__("sync" : : : "memory");
-#else
-  __asm__ __volatile__("" : : : "memory");
-#endif
 }
 
 inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {

--- a/src/conversions-inl.h
+++ b/src/conversions-inl.h
@@ -70,7 +70,11 @@ inline unsigned int FastD2UI(double x) {
   if (x < k2Pow52) {
     x += k2Pow52;
     uint32_t result;
+#ifndef BIG_ENDIAN_FLOATING_POINT
     Address mantissa_ptr = reinterpret_cast<Address>(&x);
+#else
+    Address mantissa_ptr = reinterpret_cast<Address>(&x) + 4;
+#endif
     // Copy least significant 32 bits of mantissa.
     memcpy(&result, mantissa_ptr, sizeof(result));
     return negative ? ~result + 1 : result;

--- a/src/globals.h
+++ b/src/globals.h
@@ -83,7 +83,7 @@ namespace internal {
 #if CAN_USE_UNALIGNED_ACCESSES
 #define V8_HOST_CAN_READ_UNALIGNED 1
 #endif
-#elif defined(__MIPSEL__)
+#elif defined(__MIPSEL__) || defined(__MIPSEB__)
 #define V8_HOST_ARCH_MIPS 1
 #define V8_HOST_ARCH_32_BIT 1
 #else
@@ -101,7 +101,7 @@ namespace internal {
 #define V8_TARGET_ARCH_IA32 1
 #elif defined(__ARMEL__)
 #define V8_TARGET_ARCH_ARM 1
-#elif defined(__MIPSEL__)
+#elif defined(__MIPSEL__) || defined(__MIPSEB__)
 #define V8_TARGET_ARCH_MIPS 1
 #else
 #error Target architecture was not detected as supported by v8

--- a/src/mips/builtins-mips.cc
+++ b/src/mips/builtins-mips.cc
@@ -898,11 +898,21 @@ static void Generate_JSConstructStubHelper(MacroAssembler* masm,
       // The field instance sizes contains both pre-allocated property fields
       // and in-object properties.
       __ lw(a0, FieldMemOperand(a2, Map::kInstanceSizesOffset));
+#if __BYTE_ORDER == __LITTLE_ENDIAN
       __ Ext(t6, a0, Map::kPreAllocatedPropertyFieldsByte * kBitsPerByte,
              kBitsPerByte);
       __ Addu(a3, a3, Operand(t6));
       __ Ext(t6, a0, Map::kInObjectPropertiesByte * kBitsPerByte,
               kBitsPerByte);
+#elif __BYTE_ORDER == __BIG_ENDIAN
+      __ Ext(t6, a0, (kPointerSize - Map::kPreAllocatedPropertyFieldsByte - 1) * kBitsPerByte,
+             kBitsPerByte);
+      __ Addu(a3, a3, Operand(t6));
+      __ Ext(t6, a0, (kPointerSize - Map::kInObjectPropertiesByte - 1) * kBitsPerByte,
+              kBitsPerByte);
+#else
+#error Unknown endianess
+#endif
       __ subu(a3, a3, t6);
 
       // Done if no extra properties are to be allocated.

--- a/src/mips/builtins-mips.cc
+++ b/src/mips/builtins-mips.cc
@@ -868,8 +868,15 @@ static void Generate_JSConstructStubHelper(MacroAssembler* masm,
       __ LoadRoot(t7, Heap::kUndefinedValueRootIndex);
       if (count_constructions) {
         __ lw(a0, FieldMemOperand(a2, Map::kInstanceSizesOffset));
+#if __BYTE_ORDER == __LITTLE_ENDIAN
         __ Ext(a0, a0, Map::kPreAllocatedPropertyFieldsByte * kBitsPerByte,
                 kBitsPerByte);
+#elif __BYTE_ORDER == __BIG_ENDIAN
+        __ Ext(a0, a0, (kPointerSize - Map::kPreAllocatedPropertyFieldsByte - 1) * kBitsPerByte,
+                kBitsPerByte);
+#else
+#error Unknown endianess
+#endif
         __ sll(t0, a0, kPointerSizeLog2);
         __ addu(a0, t5, t0);
         // a0: offset of first field after pre-allocated fields

--- a/src/mips/code-stubs-mips.cc
+++ b/src/mips/code-stubs-mips.cc
@@ -681,9 +681,13 @@ void FloatingPointHelper::LoadNumber(MacroAssembler* masm,
   } else {
     ASSERT(destination == kCoreRegisters);
     // Load the double from heap number to dst1 and dst2 in double format.
-    __ lw(dst1, FieldMemOperand(object, HeapNumber::kValueOffset));
-    __ lw(dst2, FieldMemOperand(object,
-        HeapNumber::kValueOffset + kPointerSize));
+#ifndef BIG_ENDIAN_FLOATING_POINT
+    __ lw(dst1, FieldMemOperand(object, HeapNumber::kMantissaOffset));
+    __ lw(dst2, FieldMemOperand(object, HeapNumber::kExponentOffset));
+#else
+    __ lw(dst1, FieldMemOperand(object, HeapNumber::kExponentOffset));
+    __ lw(dst2, FieldMemOperand(object, HeapNumber::kMantissaOffset));
+#endif
   }
   __ Branch(&done);
 
@@ -974,13 +978,13 @@ void FloatingPointHelper::LoadNumberAsInt32(MacroAssembler* masm,
 
     // Registers state after DoubleIs32BitInteger.
     // dst: mantissa[51:20].
-    // scratch2: 1
 
     // Shift back the higher bits of the mantissa.
     __ srlv(dst, dst, scratch3);
     // Set the implicit first bit.
     __ li(at, 32);
     __ subu(scratch3, at, scratch3);
+    __ li(scratch2, 1);
     __ sllv(scratch2, scratch2, scratch3);
     __ Or(dst, dst, scratch2);
     // Set the sign.
@@ -1081,8 +1085,13 @@ void FloatingPointHelper::CallCCodeForDoubleOperation(
     // calling is compiled with hard-float flag and expecting hard float ABI
     // (parameters in f12/f14 registers). We need to copy parameters from
     // a0-a3 registers to f12/f14 register pairs.
+#ifndef BIG_ENDIAN_FLOATING_POINT
     __ Move(f12, a0, a1);
     __ Move(f14, a2, a3);
+#else
+    __ Move(f12, a1, a0);
+    __ Move(f14, a3, a2);
+#endif
   }
   {
     AllowExternalCallThatCantCauseGC scope(masm);
@@ -1096,8 +1105,13 @@ void FloatingPointHelper::CallCCodeForDoubleOperation(
     __ sdc1(f0, FieldMemOperand(heap_number_result, HeapNumber::kValueOffset));
   } else {
     // Double returned in registers v0 and v1.
+#ifndef BIG_ENDIAN_FLOATING_POINT
     __ sw(v1, FieldMemOperand(heap_number_result, HeapNumber::kExponentOffset));
     __ sw(v0, FieldMemOperand(heap_number_result, HeapNumber::kMantissaOffset));
+#else
+    __ sw(v0, FieldMemOperand(heap_number_result, HeapNumber::kExponentOffset));
+    __ sw(v1, FieldMemOperand(heap_number_result, HeapNumber::kMantissaOffset));
+#endif
   }
   // Place heap_number_result in v0 and return to the pushed return address.
   __ pop(ra);
@@ -2962,8 +2976,13 @@ void BinaryOpStub::GenerateInt32Stub(MacroAssembler* masm) {
                                                    right,
                                                    destination,
                                                    f14,
+#ifndef BIG_ENDIAN_FLOATING_POINT
                                                    a2,
                                                    a3,
+#else
+                                                   a3,
+                                                   a2,
+#endif
                                                    heap_number_map,
                                                    scratch1,
                                                    scratch2,
@@ -2973,8 +2992,13 @@ void BinaryOpStub::GenerateInt32Stub(MacroAssembler* masm) {
                                                    left,
                                                    destination,
                                                    f12,
+#ifndef BIG_ENDIAN_FLOATING_POINT
                                                    t0,
                                                    t1,
+#else
+                                                   t1,
+                                                   t0,
+#endif
                                                    heap_number_map,
                                                    scratch1,
                                                    scratch2,
@@ -5908,14 +5932,18 @@ void StringHelper::GenerateCopyCharactersLong(MacroAssembler* masm,
   __ Branch(&simple_loop, eq, scratch4, Operand(zero_reg));
 
   // Loop for src/dst that are not aligned the same way.
-  // This loop uses lwl and lwr instructions. These instructions
-  // depend on the endianness, and the implementation assumes little-endian.
   {
     Label loop;
     __ bind(&loop);
+#if __BYTE_ORDER == __BIG_ENDIAN
+    __ lwl(scratch1, MemOperand(src));
+    __ Addu(src, src, Operand(kReadAlignment));
+    __ lwr(scratch1, MemOperand(src, -1));
+#else
     __ lwr(scratch1, MemOperand(src));
     __ Addu(src, src, Operand(kReadAlignment));
     __ lwl(scratch1, MemOperand(src, -1));
+#endif
     __ sw(scratch1, MemOperand(dest));
     __ Addu(dest, dest, Operand(kReadAlignment));
     __ Subu(scratch2, limit, dest);
@@ -6622,7 +6650,12 @@ void StringAddStub::Generate(MacroAssembler* masm) {
   // in a little endian mode).
   __ li(t2, Operand(2));
   __ AllocateAsciiString(v0, t2, t0, t1, t5, &call_runtime);
-  __ sh(a2, FieldMemOperand(v0, SeqAsciiString::kHeaderSize));
+#if __BYTE_ORDER == __BIG_ENDIAN
+  __ sll(t0, a2, 8);
+  __ srl(t1, a2, 8);
+  __ or_(a2, t0, t1);
+#endif
+    __ sh(a2, FieldMemOperand(v0, SeqAsciiString::kHeaderSize));
   __ IncrementCounter(counters->string_add_native(), 1, a2, a3);
   __ DropAndRet(2);
 

--- a/src/mips/stub-cache-mips.cc
+++ b/src/mips/stub-cache-mips.cc
@@ -3670,8 +3670,13 @@ void KeyedLoadStubCompiler::GenerateLoadExternalArray(
         __ ldc1(f0, MemOperand(t3, 0));
       } else {
         // t3: pointer to the beginning of the double we want to load.
+#ifndef BIG_ENDIAN_FLOATING_POINT
         __ lw(a2, MemOperand(t3, 0));
         __ lw(a3, MemOperand(t3, Register::kSizeInBytes));
+#else
+        __ lw(a2, MemOperand(t3, Register::kSizeInBytes));
+        __ lw(a3, MemOperand(t3, 0));
+#endif
       }
       break;
     case FAST_ELEMENTS:
@@ -4034,8 +4039,13 @@ void KeyedStoreStubCompiler::GenerateStoreExternalArray(
         CpuFeatures::Scope scope(FPU);
         __ sdc1(f0, MemOperand(a3, 0));
       } else {
+#ifndef BIG_ENDIAN_FLOATING_POINT
         __ sw(t2, MemOperand(a3, 0));
         __ sw(t3, MemOperand(a3, Register::kSizeInBytes));
+#else
+        __ sw(t3, MemOperand(a3, 0));
+        __ sw(t2, MemOperand(a3, Register::kSizeInBytes));
+#endif
       }
       break;
     case FAST_ELEMENTS:
@@ -4198,8 +4208,13 @@ void KeyedStoreStubCompiler::GenerateStoreExternalArray(
         __ sll(t8, key, 2);
         __ addu(t8, a3, t8);
         // t8: effective address of destination element.
+#ifndef BIG_ENDIAN_FLOATING_POINT
         __ sw(t4, MemOperand(t8, 0));
         __ sw(t3, MemOperand(t8, Register::kSizeInBytes));
+#else
+        __ sw(t3, MemOperand(t8, 0));
+        __ sw(t4, MemOperand(t8, Register::kSizeInBytes));
+#endif
         __ mov(v0, a0);
         __ Ret();
       } else {
@@ -4414,11 +4429,19 @@ void KeyedLoadStubCompiler::GenerateLoadFastDoubleElement(
   // Don't need to reload the upper 32 bits of the double, it's already in
   // scratch.
   __ sw(scratch, FieldMemOperand(heap_number_reg,
+#ifndef BIG_ENDIAN_FLOATING_POINT
                                  HeapNumber::kExponentOffset));
+#else
+                                 HeapNumber::kMantissaOffset));
+#endif
   __ lw(scratch, FieldMemOperand(indexed_double_offset,
                                  FixedArray::kHeaderSize));
   __ sw(scratch, FieldMemOperand(heap_number_reg,
+#ifndef BIG_ENDIAN_FLOATING_POINT
                                  HeapNumber::kMantissaOffset));
+#else
+                                 HeapNumber::kExponentOffset));
+#endif
 
   __ mov(v0, heap_number_reg);
   __ Ret();

--- a/src/objects.h
+++ b/src/objects.h
@@ -1330,8 +1330,13 @@ class HeapNumber: public HeapObject {
   // is a mixture of sign, exponent and mantissa.  Our current platforms are all
   // little endian apart from non-EABI arm which is little endian with big
   // endian floating point word ordering!
+#ifndef BIG_ENDIAN_FLOATING_POINT
   static const int kMantissaOffset = kValueOffset;
   static const int kExponentOffset = kValueOffset + 4;
+#else
+  static const int kMantissaOffset = kValueOffset + 4;
+  static const int kExponentOffset = kValueOffset;
+#endif
 
   static const int kSize = kValueOffset + kDoubleSize;
   static const uint32_t kSignMask = 0x80000000u;

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -8933,8 +8933,15 @@ static inline ObjectPair MakePair(MaybeObject* x, MaybeObject* y) {
 #else
 typedef uint64_t ObjectPair;
 static inline ObjectPair MakePair(MaybeObject* x, MaybeObject* y) {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
   return reinterpret_cast<uint32_t>(x) |
       (reinterpret_cast<ObjectPair>(y) << 32);
+#elif __BYTE_ORDER == __BIG_ENDIAN
+  return reinterpret_cast<uint32_t>(y) |
+      (reinterpret_cast<ObjectPair>(x) << 32);
+#else
+#error Unknown endianess
+#endif
 }
 #endif
 

--- a/test/cctest/cctest.gyp
+++ b/test/cctest/cctest.gyp
@@ -118,7 +118,7 @@
             'test-disasm-arm.cc'
           ],
         }],
-        ['v8_target_arch=="mipsel"', {
+        ['v8_target_arch=="mipsel" or v8_target_arch=="mips"', {
           'sources': [
             'test-assembler-mips.cc',
             'test-disasm-mips.cc',

--- a/test/cctest/test-assembler-mips.cc
+++ b/test/cctest/test-assembler-mips.cc
@@ -537,11 +537,21 @@ TEST(MIPS6) {
   USE(dummy);
 
   CHECK_EQ(0x11223344, t.r1);
+#if __BYTE_ORDER == __LITTLE_ENDIAN
   CHECK_EQ(0x3344, t.r2);
   CHECK_EQ(0xffffbbcc, t.r3);
   CHECK_EQ(0x0000bbcc, t.r4);
   CHECK_EQ(0xffffffcc, t.r5);
   CHECK_EQ(0x3333bbcc, t.r6);
+#elif __BYTE_ORDER == __BIG_ENDIAN
+  CHECK_EQ(0x1122, t.r2);
+  CHECK_EQ(0xffff99aa, t.r3);
+  CHECK_EQ(0x000099aa, t.r4);
+  CHECK_EQ(0xffffff99, t.r5);
+  CHECK_EQ(0x99aa3333, t.r6);
+#else
+#error Unknown endianess
+#endif
 }
 
 
@@ -955,6 +965,7 @@ TEST(MIPS11) {
   Object* dummy = CALL_GENERATED_CODE(f, &t, 0, 0, 0, 0);
   USE(dummy);
 
+#if __BYTE_ORDER == __LITTLE_ENDIAN
   CHECK_EQ(0x44bbccdd, t.lwl_0);
   CHECK_EQ(0x3344ccdd, t.lwl_1);
   CHECK_EQ(0x223344dd, t.lwl_2);
@@ -974,6 +985,29 @@ TEST(MIPS11) {
   CHECK_EQ(0xbbccdd44, t.swr_1);
   CHECK_EQ(0xccdd3344, t.swr_2);
   CHECK_EQ(0xdd223344, t.swr_3);
+#elif __BYTE_ORDER == __BIG_ENDIAN
+  CHECK_EQ(0x11223344, t.lwl_0);
+  CHECK_EQ(0x223344dd, t.lwl_1);
+  CHECK_EQ(0x3344ccdd, t.lwl_2);
+  CHECK_EQ(0x44bbccdd, t.lwl_3);
+
+  CHECK_EQ(0xaabbcc11, t.lwr_0);
+  CHECK_EQ(0xaabb1122, t.lwr_1);
+  CHECK_EQ(0xaa112233, t.lwr_2);
+  CHECK_EQ(0x11223344, t.lwr_3);
+
+  CHECK_EQ(0xaabbccdd, t.swl_0);
+  CHECK_EQ(0x11aabbcc, t.swl_1);
+  CHECK_EQ(0x1122aabb, t.swl_2);
+  CHECK_EQ(0x112233aa, t.swl_3);
+
+  CHECK_EQ(0xdd223344, t.swr_0);
+  CHECK_EQ(0xccdd3344, t.swr_1);
+  CHECK_EQ(0xbbccdd44, t.swr_2);
+  CHECK_EQ(0xaabbccdd, t.swr_3);
+#else
+#error Unknown endianess
+#endif
 }
 
 

--- a/tools/gyp/v8.gyp
+++ b/tools/gyp/v8.gyp
@@ -562,7 +562,7 @@
                 '../../src/ia32/stub-cache-ia32.cc',
               ],
             }],
-            ['v8_target_arch=="mipsel"', {
+            ['v8_target_arch=="mipsel" or v8_target_arch=="mips"', {
               'sources': [
                 '../../src/mips/assembler-mips.cc',
                 '../../src/mips/assembler-mips.h',


### PR DESCRIPTION
Hi guys,

This is a basic suport for MIPS BE.

Currently, the mips32r1 soft-float nocrankshaft mode is only supported and tested good enough. In this mode, our big-endian MIPS board passes the cctest and mjsunit test packages, as well as the V8 benchmark v.7 and SunSpider v0.9.1.

The board has a half-way implemented FPU (that is, surprisingly, it lacks some of FPU instructions like mfc1/stc1), so we didn't get it fully working at the moment with V8, although you may notice some endian-related fixes in the hard FPU related branches of execution. These fixes are assumed to be correct.

--Evgeny
